### PR TITLE
feat: added support for image signatures

### DIFF
--- a/packages/lib/translations/de/common.po
+++ b/packages/lib/translations/de/common.po
@@ -443,7 +443,7 @@ msgstr "Admin"
 msgid "Advanced Options"
 msgstr "Erweiterte Optionen"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:573
+#: packages/ui/primitives/document-flow/add-fields.tsx:575
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:406
 msgid "Advanced settings"
 msgstr "Erweiterte Einstellungen"
@@ -500,11 +500,11 @@ msgstr "Genehmigung"
 msgid "Before you get started, please confirm your email address by clicking the button below:"
 msgstr "Bitte bestätige vor dem Start deine E-Mail-Adresse, indem du auf den Button unten klickst:"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:377
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:441
 msgid "Black"
 msgstr "Schwarz"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:391
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:455
 msgid "Blue"
 msgstr "Blau"
 
@@ -558,7 +558,7 @@ msgstr "Checkbox-Werte"
 msgid "Clear filters"
 msgstr "Filter löschen"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:411
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:483
 msgid "Clear Signature"
 msgstr "Unterschrift löschen"
 
@@ -585,7 +585,7 @@ msgstr "Abgeschlossenes Dokument"
 msgid "Configure Direct Recipient"
 msgstr "Direkten Empfänger konfigurieren"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:574
+#: packages/ui/primitives/document-flow/add-fields.tsx:576
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:407
 msgid "Configure the {0} field"
 msgstr "Konfigurieren Sie das Feld {0}"
@@ -647,7 +647,7 @@ msgstr "Konto erstellen"
 msgid "Custom Text"
 msgstr "Benutzerdefinierter Text"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:927
+#: packages/ui/primitives/document-flow/add-fields.tsx:929
 #: packages/ui/primitives/document-flow/types.ts:53
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:690
 msgid "Date"
@@ -788,7 +788,7 @@ msgstr "Entwurf"
 msgid "Drag & drop your PDF here."
 msgstr "Ziehen Sie Ihr PDF hierher."
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1058
+#: packages/ui/primitives/document-flow/add-fields.tsx:1060
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:820
 msgid "Dropdown"
 msgstr "Dropdown"
@@ -798,7 +798,7 @@ msgid "Dropdown options"
 msgstr "Dropdown-Optionen"
 
 #: packages/lib/constants/document.ts:28
-#: packages/ui/primitives/document-flow/add-fields.tsx:875
+#: packages/ui/primitives/document-flow/add-fields.tsx:877
 #: packages/ui/primitives/document-flow/add-signature.tsx:272
 #: packages/ui/primitives/document-flow/add-signers.tsx:512
 #: packages/ui/primitives/document-flow/add-signers.tsx:519
@@ -825,7 +825,7 @@ msgstr "E-Mail erneut gesendet"
 msgid "Email sent"
 msgstr "E-Mail gesendet"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1123
+#: packages/ui/primitives/document-flow/add-fields.tsx:1125
 msgid "Empty field"
 msgstr "Leeres Feld"
 
@@ -838,7 +838,7 @@ msgstr "Direktlink-Signierung aktivieren"
 msgid "Enable signing order"
 msgstr "Aktiviere die Signaturreihenfolge"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:795
+#: packages/ui/primitives/document-flow/add-fields.tsx:797
 msgid "Enable Typed Signatures"
 msgstr "Aktivieren Sie getippte Unterschriften"
 
@@ -926,7 +926,7 @@ msgstr "Globale Empfängerauthentifizierung"
 msgid "Go Back"
 msgstr "Zurück"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:398
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:462
 msgid "Green"
 msgstr "Grün"
 
@@ -1020,7 +1020,7 @@ msgstr "Nachricht <0>(Optional)</0>"
 msgid "Min"
 msgstr "Min"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:901
+#: packages/ui/primitives/document-flow/add-fields.tsx:903
 #: packages/ui/primitives/document-flow/add-signature.tsx:298
 #: packages/ui/primitives/document-flow/add-signers.tsx:550
 #: packages/ui/primitives/document-flow/add-signers.tsx:556
@@ -1043,7 +1043,7 @@ msgstr "Muss unterzeichnen"
 msgid "Needs to view"
 msgstr "Muss sehen"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:686
+#: packages/ui/primitives/document-flow/add-fields.tsx:688
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:504
 msgid "No recipient matching this description was found."
 msgstr "Kein passender Empfänger mit dieser Beschreibung gefunden."
@@ -1052,7 +1052,7 @@ msgstr "Kein passender Empfänger mit dieser Beschreibung gefunden."
 msgid "No recipients"
 msgstr "Keine Empfänger"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:701
+#: packages/ui/primitives/document-flow/add-fields.tsx:703
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:519
 msgid "No recipients with this role"
 msgstr "Keine Empfänger mit dieser Rolle"
@@ -1081,7 +1081,7 @@ msgstr "Kein Wert gefunden."
 msgid "None"
 msgstr "Keine"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:979
+#: packages/ui/primitives/document-flow/add-fields.tsx:981
 #: packages/ui/primitives/document-flow/types.ts:56
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:742
 msgid "Number"
@@ -1217,7 +1217,7 @@ msgstr "E-Mail des entfernten Empfängers"
 msgid "Recipient signing request email"
 msgstr "E-Mail zur Unterzeichnungsanfrage des Empfängers"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:384
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:448
 msgid "Red"
 msgstr "Rot"
 
@@ -1254,7 +1254,7 @@ msgstr "Erinnerung: Bitte {recipientActionVerb} dieses Dokument"
 msgid "Reminder: Please {recipientActionVerb} your document"
 msgstr "Erinnerung: Bitte {recipientActionVerb} dein Dokument"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1110
+#: packages/ui/primitives/document-flow/add-fields.tsx:1112
 msgid "Remove"
 msgstr "Entfernen"
 
@@ -1374,7 +1374,7 @@ msgstr "Dokument signieren"
 msgid "Sign In"
 msgstr "Anmelden"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:823
+#: packages/ui/primitives/document-flow/add-fields.tsx:825
 #: packages/ui/primitives/document-flow/add-signature.tsx:323
 #: packages/ui/primitives/document-flow/field-icon.tsx:52
 #: packages/ui/primitives/document-flow/types.ts:49
@@ -1461,7 +1461,7 @@ msgstr "Team-E-Mail für {teamName} auf Documenso entfernt"
 msgid "Template title"
 msgstr "Vorlagentitel"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:953
+#: packages/ui/primitives/document-flow/add-fields.tsx:955
 #: packages/ui/primitives/document-flow/types.ts:52
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:716
 msgid "Text"
@@ -1558,7 +1558,7 @@ msgstr "Dies kann überschrieben werden, indem die Authentifizierungsanforderung
 msgid "This document can not be recovered, if you would like to dispute the reason for future documents please contact support."
 msgstr "Dieses Dokument kann nicht wiederhergestellt werden. Wenn du den Grund für zukünftige Dokumente anfechten möchtest, kontaktiere bitte den Support."
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:757
+#: packages/ui/primitives/document-flow/add-fields.tsx:759
 msgid "This document has already been sent to this recipient. You can no longer edit this recipient."
 msgstr "Dieses Dokument wurde bereits an diesen Empfänger gesendet. Sie können diesen Empfänger nicht mehr bearbeiten."
 
@@ -1597,7 +1597,7 @@ msgstr "Dieses Feld kann nicht geändert oder gelöscht werden. Wenn Sie den dir
 msgid "This is how the document will reach the recipients once the document is ready for signing."
 msgstr "So wird das Dokument die Empfänger erreichen, sobald es zum Unterschreiben bereit ist."
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1090
+#: packages/ui/primitives/document-flow/add-fields.tsx:1092
 msgid "This recipient can no longer be modified as they have signed a field, or completed the document."
 msgstr "Dieser Empfänger kann nicht mehr bearbeitet werden, da er ein Feld unterschrieben oder das Dokument abgeschlossen hat."
 
@@ -1626,7 +1626,7 @@ msgstr "Zeitzone"
 msgid "Title"
 msgstr "Titel"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1073
+#: packages/ui/primitives/document-flow/add-fields.tsx:1075
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:834
 msgid "To proceed further, please set at least one value for the {0} field."
 msgstr "Um fortzufahren, legen Sie bitte mindestens einen Wert für das Feld {0} fest."
@@ -1642,6 +1642,10 @@ msgstr "Aktualisieren Sie die Rolle und fügen Sie Felder nach Bedarf für den d
 #: packages/ui/primitives/document-dropzone.tsx:168
 msgid "Upgrade"
 msgstr "Upgrade"
+
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:476
+msgid "Upload Image"
+msgstr ""
 
 #: packages/ui/primitives/document-dropzone.tsx:70
 msgid "Upload Template Document"

--- a/packages/lib/translations/en/common.po
+++ b/packages/lib/translations/en/common.po
@@ -438,7 +438,7 @@ msgstr "Admin"
 msgid "Advanced Options"
 msgstr "Advanced Options"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:573
+#: packages/ui/primitives/document-flow/add-fields.tsx:575
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:406
 msgid "Advanced settings"
 msgstr "Advanced settings"
@@ -495,11 +495,11 @@ msgstr "Approving"
 msgid "Before you get started, please confirm your email address by clicking the button below:"
 msgstr "Before you get started, please confirm your email address by clicking the button below:"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:377
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:441
 msgid "Black"
 msgstr "Black"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:391
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:455
 msgid "Blue"
 msgstr "Blue"
 
@@ -553,7 +553,7 @@ msgstr "Checkbox values"
 msgid "Clear filters"
 msgstr "Clear filters"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:411
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:483
 msgid "Clear Signature"
 msgstr "Clear Signature"
 
@@ -580,7 +580,7 @@ msgstr "Completed Document"
 msgid "Configure Direct Recipient"
 msgstr "Configure Direct Recipient"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:574
+#: packages/ui/primitives/document-flow/add-fields.tsx:576
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:407
 msgid "Configure the {0} field"
 msgstr "Configure the {0} field"
@@ -642,7 +642,7 @@ msgstr "Create account"
 msgid "Custom Text"
 msgstr "Custom Text"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:927
+#: packages/ui/primitives/document-flow/add-fields.tsx:929
 #: packages/ui/primitives/document-flow/types.ts:53
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:690
 msgid "Date"
@@ -783,7 +783,7 @@ msgstr "Draft"
 msgid "Drag & drop your PDF here."
 msgstr "Drag & drop your PDF here."
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1058
+#: packages/ui/primitives/document-flow/add-fields.tsx:1060
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:820
 msgid "Dropdown"
 msgstr "Dropdown"
@@ -793,7 +793,7 @@ msgid "Dropdown options"
 msgstr "Dropdown options"
 
 #: packages/lib/constants/document.ts:28
-#: packages/ui/primitives/document-flow/add-fields.tsx:875
+#: packages/ui/primitives/document-flow/add-fields.tsx:877
 #: packages/ui/primitives/document-flow/add-signature.tsx:272
 #: packages/ui/primitives/document-flow/add-signers.tsx:512
 #: packages/ui/primitives/document-flow/add-signers.tsx:519
@@ -820,7 +820,7 @@ msgstr "Email resent"
 msgid "Email sent"
 msgstr "Email sent"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1123
+#: packages/ui/primitives/document-flow/add-fields.tsx:1125
 msgid "Empty field"
 msgstr "Empty field"
 
@@ -833,7 +833,7 @@ msgstr "Enable Direct Link Signing"
 msgid "Enable signing order"
 msgstr "Enable signing order"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:795
+#: packages/ui/primitives/document-flow/add-fields.tsx:797
 msgid "Enable Typed Signatures"
 msgstr "Enable Typed Signatures"
 
@@ -921,7 +921,7 @@ msgstr "Global recipient action authentication"
 msgid "Go Back"
 msgstr "Go Back"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:398
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:462
 msgid "Green"
 msgstr "Green"
 
@@ -1015,7 +1015,7 @@ msgstr "Message <0>(Optional)</0>"
 msgid "Min"
 msgstr "Min"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:901
+#: packages/ui/primitives/document-flow/add-fields.tsx:903
 #: packages/ui/primitives/document-flow/add-signature.tsx:298
 #: packages/ui/primitives/document-flow/add-signers.tsx:550
 #: packages/ui/primitives/document-flow/add-signers.tsx:556
@@ -1038,7 +1038,7 @@ msgstr "Needs to sign"
 msgid "Needs to view"
 msgstr "Needs to view"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:686
+#: packages/ui/primitives/document-flow/add-fields.tsx:688
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:504
 msgid "No recipient matching this description was found."
 msgstr "No recipient matching this description was found."
@@ -1047,7 +1047,7 @@ msgstr "No recipient matching this description was found."
 msgid "No recipients"
 msgstr "No recipients"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:701
+#: packages/ui/primitives/document-flow/add-fields.tsx:703
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:519
 msgid "No recipients with this role"
 msgstr "No recipients with this role"
@@ -1076,7 +1076,7 @@ msgstr "No value found."
 msgid "None"
 msgstr "None"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:979
+#: packages/ui/primitives/document-flow/add-fields.tsx:981
 #: packages/ui/primitives/document-flow/types.ts:56
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:742
 msgid "Number"
@@ -1212,7 +1212,7 @@ msgstr "Recipient removed email"
 msgid "Recipient signing request email"
 msgstr "Recipient signing request email"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:384
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:448
 msgid "Red"
 msgstr "Red"
 
@@ -1249,7 +1249,7 @@ msgstr "Reminder: Please {recipientActionVerb} this document"
 msgid "Reminder: Please {recipientActionVerb} your document"
 msgstr "Reminder: Please {recipientActionVerb} your document"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1110
+#: packages/ui/primitives/document-flow/add-fields.tsx:1112
 msgid "Remove"
 msgstr "Remove"
 
@@ -1369,7 +1369,7 @@ msgstr "Sign Document"
 msgid "Sign In"
 msgstr "Sign In"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:823
+#: packages/ui/primitives/document-flow/add-fields.tsx:825
 #: packages/ui/primitives/document-flow/add-signature.tsx:323
 #: packages/ui/primitives/document-flow/field-icon.tsx:52
 #: packages/ui/primitives/document-flow/types.ts:49
@@ -1456,7 +1456,7 @@ msgstr "Team email removed for {teamName} on Documenso"
 msgid "Template title"
 msgstr "Template title"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:953
+#: packages/ui/primitives/document-flow/add-fields.tsx:955
 #: packages/ui/primitives/document-flow/types.ts:52
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:716
 msgid "Text"
@@ -1553,7 +1553,7 @@ msgstr "This can be overriden by setting the authentication requirements directl
 msgid "This document can not be recovered, if you would like to dispute the reason for future documents please contact support."
 msgstr "This document can not be recovered, if you would like to dispute the reason for future documents please contact support."
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:757
+#: packages/ui/primitives/document-flow/add-fields.tsx:759
 msgid "This document has already been sent to this recipient. You can no longer edit this recipient."
 msgstr "This document has already been sent to this recipient. You can no longer edit this recipient."
 
@@ -1592,7 +1592,7 @@ msgstr "This field cannot be modified or deleted. When you share this template's
 msgid "This is how the document will reach the recipients once the document is ready for signing."
 msgstr "This is how the document will reach the recipients once the document is ready for signing."
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1090
+#: packages/ui/primitives/document-flow/add-fields.tsx:1092
 msgid "This recipient can no longer be modified as they have signed a field, or completed the document."
 msgstr "This recipient can no longer be modified as they have signed a field, or completed the document."
 
@@ -1621,7 +1621,7 @@ msgstr "Time Zone"
 msgid "Title"
 msgstr "Title"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1073
+#: packages/ui/primitives/document-flow/add-fields.tsx:1075
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:834
 msgid "To proceed further, please set at least one value for the {0} field."
 msgstr "To proceed further, please set at least one value for the {0} field."
@@ -1637,6 +1637,10 @@ msgstr "Update the role and add fields as required for the direct recipient. The
 #: packages/ui/primitives/document-dropzone.tsx:168
 msgid "Upgrade"
 msgstr "Upgrade"
+
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:476
+msgid "Upload Image"
+msgstr "Upload Image"
 
 #: packages/ui/primitives/document-dropzone.tsx:70
 msgid "Upload Template Document"

--- a/packages/lib/translations/es/common.po
+++ b/packages/lib/translations/es/common.po
@@ -443,7 +443,7 @@ msgstr "Admin"
 msgid "Advanced Options"
 msgstr "Opciones avanzadas"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:573
+#: packages/ui/primitives/document-flow/add-fields.tsx:575
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:406
 msgid "Advanced settings"
 msgstr "Configuraciones avanzadas"
@@ -500,11 +500,11 @@ msgstr "Aprobando"
 msgid "Before you get started, please confirm your email address by clicking the button below:"
 msgstr "Antes de comenzar, por favor confirma tu dirección de correo electrónico haciendo clic en el botón de abajo:"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:377
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:441
 msgid "Black"
 msgstr "Negro"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:391
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:455
 msgid "Blue"
 msgstr "Azul"
 
@@ -558,7 +558,7 @@ msgstr "Valores de Checkbox"
 msgid "Clear filters"
 msgstr "Limpiar filtros"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:411
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:483
 msgid "Clear Signature"
 msgstr "Limpiar firma"
 
@@ -585,7 +585,7 @@ msgstr "Documento completado"
 msgid "Configure Direct Recipient"
 msgstr "Configurar destinatario directo"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:574
+#: packages/ui/primitives/document-flow/add-fields.tsx:576
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:407
 msgid "Configure the {0} field"
 msgstr "Configurar el campo {0}"
@@ -647,7 +647,7 @@ msgstr "Crear cuenta"
 msgid "Custom Text"
 msgstr "Texto personalizado"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:927
+#: packages/ui/primitives/document-flow/add-fields.tsx:929
 #: packages/ui/primitives/document-flow/types.ts:53
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:690
 msgid "Date"
@@ -788,7 +788,7 @@ msgstr "Borrador"
 msgid "Drag & drop your PDF here."
 msgstr "Arrastre y suelte su PDF aquí."
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1058
+#: packages/ui/primitives/document-flow/add-fields.tsx:1060
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:820
 msgid "Dropdown"
 msgstr "Menú desplegable"
@@ -798,7 +798,7 @@ msgid "Dropdown options"
 msgstr "Opciones de menú desplegable"
 
 #: packages/lib/constants/document.ts:28
-#: packages/ui/primitives/document-flow/add-fields.tsx:875
+#: packages/ui/primitives/document-flow/add-fields.tsx:877
 #: packages/ui/primitives/document-flow/add-signature.tsx:272
 #: packages/ui/primitives/document-flow/add-signers.tsx:512
 #: packages/ui/primitives/document-flow/add-signers.tsx:519
@@ -825,7 +825,7 @@ msgstr "Correo electrónico reeenviado"
 msgid "Email sent"
 msgstr "Correo electrónico enviado"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1123
+#: packages/ui/primitives/document-flow/add-fields.tsx:1125
 msgid "Empty field"
 msgstr "Campo vacío"
 
@@ -838,7 +838,7 @@ msgstr "Habilitar firma de enlace directo"
 msgid "Enable signing order"
 msgstr "Habilitar orden de firma"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:795
+#: packages/ui/primitives/document-flow/add-fields.tsx:797
 msgid "Enable Typed Signatures"
 msgstr "Habilitar firmas escritas"
 
@@ -926,7 +926,7 @@ msgstr "Autenticación de acción de destinatario global"
 msgid "Go Back"
 msgstr "Regresar"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:398
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:462
 msgid "Green"
 msgstr "Verde"
 
@@ -1020,7 +1020,7 @@ msgstr "Mensaje <0>(Opcional)</0>"
 msgid "Min"
 msgstr "Mín"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:901
+#: packages/ui/primitives/document-flow/add-fields.tsx:903
 #: packages/ui/primitives/document-flow/add-signature.tsx:298
 #: packages/ui/primitives/document-flow/add-signers.tsx:550
 #: packages/ui/primitives/document-flow/add-signers.tsx:556
@@ -1043,7 +1043,7 @@ msgstr "Necesita firmar"
 msgid "Needs to view"
 msgstr "Necesita ver"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:686
+#: packages/ui/primitives/document-flow/add-fields.tsx:688
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:504
 msgid "No recipient matching this description was found."
 msgstr "No se encontró ningún destinatario que coincidiera con esta descripción."
@@ -1052,7 +1052,7 @@ msgstr "No se encontró ningún destinatario que coincidiera con esta descripci�
 msgid "No recipients"
 msgstr "Sin destinatarios"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:701
+#: packages/ui/primitives/document-flow/add-fields.tsx:703
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:519
 msgid "No recipients with this role"
 msgstr "No hay destinatarios con este rol"
@@ -1081,7 +1081,7 @@ msgstr "No se encontró valor."
 msgid "None"
 msgstr "Ninguno"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:979
+#: packages/ui/primitives/document-flow/add-fields.tsx:981
 #: packages/ui/primitives/document-flow/types.ts:56
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:742
 msgid "Number"
@@ -1217,7 +1217,7 @@ msgstr "Correo electrónico de destinatario eliminado"
 msgid "Recipient signing request email"
 msgstr "Correo electrónico de solicitud de firma de destinatario"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:384
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:448
 msgid "Red"
 msgstr "Rojo"
 
@@ -1254,7 +1254,7 @@ msgstr "Recordatorio: Por favor {recipientActionVerb} este documento"
 msgid "Reminder: Please {recipientActionVerb} your document"
 msgstr "Recordatorio: Por favor {recipientActionVerb} tu documento"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1110
+#: packages/ui/primitives/document-flow/add-fields.tsx:1112
 msgid "Remove"
 msgstr "Eliminar"
 
@@ -1374,7 +1374,7 @@ msgstr "Firmar Documento"
 msgid "Sign In"
 msgstr "Iniciar sesión"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:823
+#: packages/ui/primitives/document-flow/add-fields.tsx:825
 #: packages/ui/primitives/document-flow/add-signature.tsx:323
 #: packages/ui/primitives/document-flow/field-icon.tsx:52
 #: packages/ui/primitives/document-flow/types.ts:49
@@ -1461,7 +1461,7 @@ msgstr "Correo electrónico del equipo eliminado para {teamName} en Documenso"
 msgid "Template title"
 msgstr "Título de plantilla"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:953
+#: packages/ui/primitives/document-flow/add-fields.tsx:955
 #: packages/ui/primitives/document-flow/types.ts:52
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:716
 msgid "Text"
@@ -1558,7 +1558,7 @@ msgstr "Esto se puede anular configurando los requisitos de autenticación direc
 msgid "This document can not be recovered, if you would like to dispute the reason for future documents please contact support."
 msgstr "Este documento no se puede recuperar, si deseas impugnar la razón para documentos futuros, por favor contacta con el soporte."
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:757
+#: packages/ui/primitives/document-flow/add-fields.tsx:759
 msgid "This document has already been sent to this recipient. You can no longer edit this recipient."
 msgstr "Este documento ya ha sido enviado a este destinatario. Ya no puede editar a este destinatario."
 
@@ -1597,7 +1597,7 @@ msgstr "Este campo no se puede modificar ni eliminar. Cuando comparta el enlace 
 msgid "This is how the document will reach the recipients once the document is ready for signing."
 msgstr "Así es como el documento llegará a los destinatarios una vez que esté listo para firmarse."
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1090
+#: packages/ui/primitives/document-flow/add-fields.tsx:1092
 msgid "This recipient can no longer be modified as they have signed a field, or completed the document."
 msgstr "Este destinatario ya no puede ser modificado ya que ha firmado un campo o completado el documento."
 
@@ -1626,7 +1626,7 @@ msgstr "Zona horaria"
 msgid "Title"
 msgstr "Título"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1073
+#: packages/ui/primitives/document-flow/add-fields.tsx:1075
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:834
 msgid "To proceed further, please set at least one value for the {0} field."
 msgstr "Para continuar, por favor establezca al menos un valor para el campo {0}."
@@ -1642,6 +1642,10 @@ msgstr "Actualizar el rol y agregar campos según sea necesario para el destinat
 #: packages/ui/primitives/document-dropzone.tsx:168
 msgid "Upgrade"
 msgstr "Actualizar"
+
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:476
+msgid "Upload Image"
+msgstr ""
 
 #: packages/ui/primitives/document-dropzone.tsx:70
 msgid "Upload Template Document"

--- a/packages/lib/translations/fr/common.po
+++ b/packages/lib/translations/fr/common.po
@@ -443,7 +443,7 @@ msgstr "Administrateur"
 msgid "Advanced Options"
 msgstr "Options avancées"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:573
+#: packages/ui/primitives/document-flow/add-fields.tsx:575
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:406
 msgid "Advanced settings"
 msgstr "Paramètres avancés"
@@ -500,11 +500,11 @@ msgstr "En attente d'approbation"
 msgid "Before you get started, please confirm your email address by clicking the button below:"
 msgstr "Avant de commencer, veuillez confirmer votre adresse email en cliquant sur le bouton ci-dessous :"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:377
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:441
 msgid "Black"
 msgstr "Noir"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:391
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:455
 msgid "Blue"
 msgstr "Bleu"
 
@@ -558,7 +558,7 @@ msgstr "Valeurs de case à cocher"
 msgid "Clear filters"
 msgstr "Effacer les filtres"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:411
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:483
 msgid "Clear Signature"
 msgstr "Effacer la signature"
 
@@ -585,7 +585,7 @@ msgstr "Document Terminé"
 msgid "Configure Direct Recipient"
 msgstr "Configurer le destinataire direct"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:574
+#: packages/ui/primitives/document-flow/add-fields.tsx:576
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:407
 msgid "Configure the {0} field"
 msgstr "Configurer le champ {0}"
@@ -647,7 +647,7 @@ msgstr "Créer un compte"
 msgid "Custom Text"
 msgstr "Texte personnalisé"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:927
+#: packages/ui/primitives/document-flow/add-fields.tsx:929
 #: packages/ui/primitives/document-flow/types.ts:53
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:690
 msgid "Date"
@@ -788,7 +788,7 @@ msgstr "Brouillon"
 msgid "Drag & drop your PDF here."
 msgstr "Faites glisser et déposez votre PDF ici."
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1058
+#: packages/ui/primitives/document-flow/add-fields.tsx:1060
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:820
 msgid "Dropdown"
 msgstr "Liste déroulante"
@@ -798,7 +798,7 @@ msgid "Dropdown options"
 msgstr "Options de liste déroulante"
 
 #: packages/lib/constants/document.ts:28
-#: packages/ui/primitives/document-flow/add-fields.tsx:875
+#: packages/ui/primitives/document-flow/add-fields.tsx:877
 #: packages/ui/primitives/document-flow/add-signature.tsx:272
 #: packages/ui/primitives/document-flow/add-signers.tsx:512
 #: packages/ui/primitives/document-flow/add-signers.tsx:519
@@ -825,7 +825,7 @@ msgstr "Email renvoyé"
 msgid "Email sent"
 msgstr "Email envoyé"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1123
+#: packages/ui/primitives/document-flow/add-fields.tsx:1125
 msgid "Empty field"
 msgstr "Champ vide"
 
@@ -838,7 +838,7 @@ msgstr "Activer la signature de lien direct"
 msgid "Enable signing order"
 msgstr "Activer l'ordre de signature"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:795
+#: packages/ui/primitives/document-flow/add-fields.tsx:797
 msgid "Enable Typed Signatures"
 msgstr "Activer les signatures tapées"
 
@@ -926,7 +926,7 @@ msgstr "Authentification d'action de destinataire globale"
 msgid "Go Back"
 msgstr "Retourner"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:398
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:462
 msgid "Green"
 msgstr "Vert"
 
@@ -1020,7 +1020,7 @@ msgstr "Message <0>(Optionnel)</0>"
 msgid "Min"
 msgstr "Min"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:901
+#: packages/ui/primitives/document-flow/add-fields.tsx:903
 #: packages/ui/primitives/document-flow/add-signature.tsx:298
 #: packages/ui/primitives/document-flow/add-signers.tsx:550
 #: packages/ui/primitives/document-flow/add-signers.tsx:556
@@ -1043,7 +1043,7 @@ msgstr "Nécessite une signature"
 msgid "Needs to view"
 msgstr "Nécessite une visualisation"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:686
+#: packages/ui/primitives/document-flow/add-fields.tsx:688
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:504
 msgid "No recipient matching this description was found."
 msgstr "Aucun destinataire correspondant à cette description n'a été trouvé."
@@ -1052,7 +1052,7 @@ msgstr "Aucun destinataire correspondant à cette description n'a été trouvé.
 msgid "No recipients"
 msgstr "Aucun destinataire"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:701
+#: packages/ui/primitives/document-flow/add-fields.tsx:703
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:519
 msgid "No recipients with this role"
 msgstr "Aucun destinataire avec ce rôle"
@@ -1081,7 +1081,7 @@ msgstr "Aucune valeur trouvée."
 msgid "None"
 msgstr "Aucun"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:979
+#: packages/ui/primitives/document-flow/add-fields.tsx:981
 #: packages/ui/primitives/document-flow/types.ts:56
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:742
 msgid "Number"
@@ -1217,7 +1217,7 @@ msgstr "E-mail de destinataire supprimé"
 msgid "Recipient signing request email"
 msgstr "E-mail de demande de signature de destinataire"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:384
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:448
 msgid "Red"
 msgstr "Rouge"
 
@@ -1254,7 +1254,7 @@ msgstr "Rappel : Veuillez {recipientActionVerb} ce document"
 msgid "Reminder: Please {recipientActionVerb} your document"
 msgstr "Rappel : Veuillez {recipientActionVerb} votre document"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1110
+#: packages/ui/primitives/document-flow/add-fields.tsx:1112
 msgid "Remove"
 msgstr "Retirer"
 
@@ -1374,7 +1374,7 @@ msgstr "Signer le document"
 msgid "Sign In"
 msgstr "Se connecter"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:823
+#: packages/ui/primitives/document-flow/add-fields.tsx:825
 #: packages/ui/primitives/document-flow/add-signature.tsx:323
 #: packages/ui/primitives/document-flow/field-icon.tsx:52
 #: packages/ui/primitives/document-flow/types.ts:49
@@ -1461,7 +1461,7 @@ msgstr "Email d'équipe supprimé pour {teamName} sur Documenso"
 msgid "Template title"
 msgstr "Titre du modèle"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:953
+#: packages/ui/primitives/document-flow/add-fields.tsx:955
 #: packages/ui/primitives/document-flow/types.ts:52
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:716
 msgid "Text"
@@ -1558,7 +1558,7 @@ msgstr "Cela peut être remplacé par le paramétrage direct des exigences d'aut
 msgid "This document can not be recovered, if you would like to dispute the reason for future documents please contact support."
 msgstr "Ce document ne peut pas être récupéré, si vous souhaitez contester la raison des documents futurs, veuillez contacter le support."
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:757
+#: packages/ui/primitives/document-flow/add-fields.tsx:759
 msgid "This document has already been sent to this recipient. You can no longer edit this recipient."
 msgstr "Ce document a déjà été envoyé à ce destinataire. Vous ne pouvez plus modifier ce destinataire."
 
@@ -1597,7 +1597,7 @@ msgstr "Ce champ ne peut pas être modifié ou supprimé. Lorsque vous partagez 
 msgid "This is how the document will reach the recipients once the document is ready for signing."
 msgstr "Voici comment le document atteindra les destinataires une fois qu'il sera prêt à être signé."
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1090
+#: packages/ui/primitives/document-flow/add-fields.tsx:1092
 msgid "This recipient can no longer be modified as they have signed a field, or completed the document."
 msgstr "Ce destinataire ne peut plus être modifié car il a signé un champ ou complété le document."
 
@@ -1626,7 +1626,7 @@ msgstr "Fuseau horaire"
 msgid "Title"
 msgstr "Titre"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1073
+#: packages/ui/primitives/document-flow/add-fields.tsx:1075
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:834
 msgid "To proceed further, please set at least one value for the {0} field."
 msgstr "Pour continuer, veuillez définir au moins une valeur pour le champ {0}."
@@ -1642,6 +1642,10 @@ msgstr "Mettez à jour le rôle et ajoutez des champs selon les besoins pour le 
 #: packages/ui/primitives/document-dropzone.tsx:168
 msgid "Upgrade"
 msgstr "Améliorer"
+
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:476
+msgid "Upload Image"
+msgstr ""
 
 #: packages/ui/primitives/document-dropzone.tsx:70
 msgid "Upload Template Document"

--- a/packages/lib/translations/zh-tw/common.po
+++ b/packages/lib/translations/zh-tw/common.po
@@ -414,7 +414,7 @@ msgstr "管理員"
 msgid "Advanced Options"
 msgstr "進階選項"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:573
+#: packages/ui/primitives/document-flow/add-fields.tsx:575
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:406
 msgid "Advanced settings"
 msgstr "進階設定"
@@ -467,11 +467,11 @@ msgstr "核准中"
 msgid "Before you get started, please confirm your email address by clicking the button below:"
 msgstr "在開始之前，請點擊下方按鈕確認您的電子郵件地址："
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:377
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:441
 msgid "Black"
 msgstr "黑色"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:391
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:455
 msgid "Blue"
 msgstr "藍色"
 
@@ -525,7 +525,7 @@ msgstr "核取方塊值"
 msgid "Clear filters"
 msgstr "清除篩選條件"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:411
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:483
 msgid "Clear Signature"
 msgstr "清除簽名"
 
@@ -552,7 +552,7 @@ msgstr "已完成文件"
 msgid "Configure Direct Recipient"
 msgstr "配置直接接收者"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:574
+#: packages/ui/primitives/document-flow/add-fields.tsx:576
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:407
 msgid "Configure the {0} field"
 msgstr "配置 {0} 欄位"
@@ -610,7 +610,7 @@ msgstr "建立帳戶"
 msgid "Custom Text"
 msgstr "自訂文字"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:927
+#: packages/ui/primitives/document-flow/add-fields.tsx:929
 #: packages/ui/primitives/document-flow/types.ts:53
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:690
 msgid "Date"
@@ -748,7 +748,7 @@ msgstr "草稿"
 msgid "Drag & drop your PDF here."
 msgstr "將您的 PDF 拖放到此處。"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1058
+#: packages/ui/primitives/document-flow/add-fields.tsx:1060
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:820
 msgid "Dropdown"
 msgstr "下拉選單"
@@ -758,7 +758,7 @@ msgid "Dropdown options"
 msgstr "下拉選項"
 
 #: packages/lib/constants/document.ts:28
-#: packages/ui/primitives/document-flow/add-fields.tsx:875
+#: packages/ui/primitives/document-flow/add-fields.tsx:877
 #: packages/ui/primitives/document-flow/add-signature.tsx:272
 #: packages/ui/primitives/document-flow/add-signers.tsx:512
 #: packages/ui/primitives/document-flow/add-signers.tsx:519
@@ -785,7 +785,7 @@ msgstr "已重新發送電子郵件"
 msgid "Email sent"
 msgstr "電子郵件已發送"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1123
+#: packages/ui/primitives/document-flow/add-fields.tsx:1125
 msgid "Empty field"
 msgstr "空白欄位"
 
@@ -798,7 +798,7 @@ msgstr "啟用直接連結簽署"
 msgid "Enable signing order"
 msgstr "啟用簽署順序"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:795
+#: packages/ui/primitives/document-flow/add-fields.tsx:797
 msgid "Enable Typed Signatures"
 msgstr "啟用鍵入簽名"
 
@@ -886,7 +886,7 @@ msgstr "全球接收者操作驗證"
 msgid "Go Back"
 msgstr "返回"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:398
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:462
 msgid "Green"
 msgstr "綠色"
 
@@ -977,7 +977,7 @@ msgstr "訊息 <0>（可選）</0>"
 msgid "Min"
 msgstr "分鐘"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:901
+#: packages/ui/primitives/document-flow/add-fields.tsx:903
 #: packages/ui/primitives/document-flow/add-signature.tsx:298
 #: packages/ui/primitives/document-flow/add-signers.tsx:550
 #: packages/ui/primitives/document-flow/add-signers.tsx:556
@@ -1000,7 +1000,7 @@ msgstr "需要簽署"
 msgid "Needs to view"
 msgstr "需要檢視"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:686
+#: packages/ui/primitives/document-flow/add-fields.tsx:688
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:504
 msgid "No recipient matching this description was found."
 msgstr "找不到符合此描述的收件人。"
@@ -1009,7 +1009,7 @@ msgstr "找不到符合此描述的收件人。"
 msgid "No recipients"
 msgstr "無收件人"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:701
+#: packages/ui/primitives/document-flow/add-fields.tsx:703
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:519
 msgid "No recipients with this role"
 msgstr "此角色沒有收件人"
@@ -1038,7 +1038,7 @@ msgstr "未找到值。"
 msgid "None"
 msgstr "無"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:979
+#: packages/ui/primitives/document-flow/add-fields.tsx:981
 #: packages/ui/primitives/document-flow/types.ts:56
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:742
 msgid "Number"
@@ -1174,7 +1174,7 @@ msgstr "收件者已刪除電子郵件"
 msgid "Recipient signing request email"
 msgstr "收件者簽署請求電郵"
 
-#: packages/ui/primitives/signature-pad/signature-pad.tsx:384
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:448
 msgid "Red"
 msgstr "紅色"
 
@@ -1211,7 +1211,7 @@ msgstr "提醒：請{recipientActionVerb}此文件"
 msgid "Reminder: Please {recipientActionVerb} your document"
 msgstr "提醒：請{recipientActionVerb}您的文件"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1110
+#: packages/ui/primitives/document-flow/add-fields.tsx:1112
 msgid "Remove"
 msgstr "移除"
 
@@ -1331,7 +1331,7 @@ msgstr "簽署文件"
 msgid "Sign In"
 msgstr "登入"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:823
+#: packages/ui/primitives/document-flow/add-fields.tsx:825
 #: packages/ui/primitives/document-flow/add-signature.tsx:323
 #: packages/ui/primitives/document-flow/field-icon.tsx:52
 #: packages/ui/primitives/document-flow/types.ts:49
@@ -1414,7 +1414,7 @@ msgstr "Documenso 上 {teamName} 的團隊電子郵件已被移除"
 msgid "Template title"
 msgstr "範本標題"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:953
+#: packages/ui/primitives/document-flow/add-fields.tsx:955
 #: packages/ui/primitives/document-flow/types.ts:52
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:716
 msgid "Text"
@@ -1508,7 +1508,7 @@ msgstr "這可以通過在下一步直接為每個接收者設定身份驗證要
 msgid "This document can not be recovered, if you would like to dispute the reason for future documents please contact support."
 msgstr "此文件無法恢復，如果您想要對未來文件的原因提出異議，請聯絡支援。"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:757
+#: packages/ui/primitives/document-flow/add-fields.tsx:759
 msgid "This document has already been sent to this recipient. You can no longer edit this recipient."
 msgstr "此文件已經發送給此接收者。您無法再編輯此接收者。"
 
@@ -1544,7 +1544,7 @@ msgstr "此欄位無法修改或刪除。當您分享此範本的直接連結或
 msgid "This is how the document will reach the recipients once the document is ready for signing."
 msgstr "這是文件準備好進行簽署後將如何送達給收件人的方式。"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1090
+#: packages/ui/primitives/document-flow/add-fields.tsx:1092
 msgid "This recipient can no longer be modified as they have signed a field, or completed the document."
 msgstr "此收件人已經簽署了一個欄位或完成了文件，因此無法再進行修改。"
 
@@ -1573,7 +1573,7 @@ msgstr "時區"
 msgid "Title"
 msgstr "標題"
 
-#: packages/ui/primitives/document-flow/add-fields.tsx:1073
+#: packages/ui/primitives/document-flow/add-fields.tsx:1075
 #: packages/ui/primitives/template-flow/add-template-fields.tsx:834
 msgid "To proceed further, please set at least one value for the {0} field."
 msgstr "若要繼續，請至少為 {0} 欄位設定一個值。"
@@ -1589,6 +1589,10 @@ msgstr "更新角色並根據需要為直接收件人新增欄位。使用直接
 #: packages/ui/primitives/document-dropzone.tsx:168
 msgid "Upgrade"
 msgstr "升級"
+
+#: packages/ui/primitives/signature-pad/signature-pad.tsx:476
+msgid "Upload Image"
+msgstr "Upload Image"
 
 #: packages/ui/primitives/document-dropzone.tsx:70
 msgid "Upload Template Document"

--- a/packages/ui/primitives/document-flow/add-fields.tsx
+++ b/packages/ui/primitives/document-flow/add-fields.tsx
@@ -78,6 +78,8 @@ const fontCaveat = Caveat({
 
 const MIN_HEIGHT_PX = 20;
 const MIN_WIDTH_PX = 80;
+const DEFAULT_HEIGHT_PX = 50;
+const DEFAULT_WIDTH_PX = 140;
 
 export type FieldFormType = {
   nativeId?: number;
@@ -480,8 +482,8 @@ export const AddFieldsFormPartial = ({
       }
 
       fieldBounds.current = {
-        height: Math.max(MIN_HEIGHT_PX),
-        width: Math.max(MIN_WIDTH_PX),
+        height: Math.max(DEFAULT_HEIGHT_PX),
+        width: Math.max(DEFAULT_WIDTH_PX),
       };
     });
 
@@ -630,8 +632,8 @@ export const AddFieldsFormPartial = ({
                         selectedSigner?.email !== field.signerEmail ||
                         !canRecipientBeModified(selectedSigner, fields)
                       }
-                      minHeight={fieldBounds.current.height}
-                      minWidth={fieldBounds.current.width}
+                      minHeight={MIN_HEIGHT_PX}
+                      minWidth={MIN_WIDTH_PX}
                       passive={isFieldWithinBounds && !!selectedField}
                       onFocus={() => setLastActiveField(field)}
                       onBlur={() => setLastActiveField(null)}

--- a/packages/ui/primitives/signature-pad/signature-pad.tsx
+++ b/packages/ui/primitives/signature-pad/signature-pad.tsx
@@ -9,6 +9,7 @@ import { Trans } from '@lingui/macro';
 import { Undo2 } from 'lucide-react';
 import type { StrokeOptions } from 'perfect-freehand';
 import { getStroke } from 'perfect-freehand';
+import { useDropzone } from 'react-dropzone';
 
 import { unsafe_useEffectOnce } from '@documenso/lib/client-only/hooks/use-effect-once';
 import { Input } from '@documenso/ui/primitives/input';
@@ -57,6 +58,55 @@ export const SignaturePad = ({
   const [currentLine, setCurrentLine] = useState<Point[]>([]);
   const [selectedColor, setSelectedColor] = useState('black');
   const [typedSignature, setTypedSignature] = useState('');
+  const [uploadedSignature, setUploadedSignature] = useState<File | null>(null);
+
+  const { open, getRootProps, getInputProps, inputRef } = useDropzone({
+    noClick: true,
+    accept: {
+      'image/*': ['.png', '.jpg', '.jpeg', '.gif'],
+    },
+    maxFiles: 1,
+    onDropAccepted(files) {
+      setUploadedSignature(files[0]);
+    },
+  });
+
+  useEffect(() => {
+    if (!uploadedSignature) {
+      return;
+    }
+
+    const url = URL.createObjectURL(uploadedSignature);
+
+    const img = new Image();
+    img.src = url;
+
+    img.onload = () => {
+      if (!$el.current || !inputRef.current) return;
+
+      const ctx = $el.current.getContext('2d');
+      const { width, height } = $el.current;
+
+      const ratio = Math.min(width / img.width, height / img.height);
+
+      ctx?.clearRect(0, 0, width, height);
+      ctx?.drawImage(
+        img,
+        0,
+        0,
+        img.width,
+        img.height,
+        (width - img.width * ratio) / 2,
+        (height - img.height * ratio) / 2,
+        img.width * ratio,
+        img.height * ratio,
+      );
+
+      $imageData.current = ctx?.getImageData(0, 0, width, height) || null;
+
+      onChange?.($el.current.toDataURL());
+    };
+  }, [inputRef, onChange, uploadedSignature]);
 
   const perfectFreehandOptions = useMemo(() => {
     const size = $el.current ? Math.min($el.current.height, $el.current.width) * 0.03 : 10;
@@ -197,6 +247,7 @@ export const SignaturePad = ({
     setTypedSignature('');
     setLines([]);
     setCurrentLine([]);
+    setUploadedSignature(null);
   };
 
   const renderTypedSignature = () => {
@@ -314,7 +365,19 @@ export const SignaturePad = ({
       const img = new Image();
 
       img.onload = () => {
-        ctx?.drawImage(img, 0, 0, Math.min(width, img.width), Math.min(height, img.height));
+        const ratio = Math.min(width / img.width, height / img.height);
+
+        ctx?.drawImage(
+          img,
+          0,
+          0,
+          img.width,
+          img.height,
+          (width - img.width * ratio) / 2,
+          (height - img.height * ratio) / 2,
+          img.width * ratio,
+          img.height * ratio,
+        );
 
         const defaultImageData = ctx?.getImageData(0, 0, width, height) || null;
 
@@ -330,13 +393,14 @@ export const SignaturePad = ({
       className={cn('relative block', containerClassName, {
         'pointer-events-none opacity-50': disabled,
       })}
+      {...getRootProps()}
     >
       <canvas
         ref={$el}
         className={cn(
           'relative block',
           {
-            'dark:hue-rotate-180 dark:invert': selectedColor === 'black',
+            'dark:hue-rotate-180 dark:invert': selectedColor === 'black' && !uploadedSignature,
           },
           className,
         )}
@@ -363,6 +427,17 @@ export const SignaturePad = ({
           />
         </div>
       )}
+
+      <div className="text-foreground absolute left-2 top-2">
+        <input {...getInputProps()} />
+        <button
+          type="button"
+          className="focus-visible:ring-ring ring-offset-background text-muted-foreground/60 hover:text-muted-foreground rounded-full p-0 text-[0.688rem] focus-visible:outline-none focus-visible:ring-2"
+          onClick={open}
+        >
+          <Trans>Upload Image</Trans>
+        </button>
+      </div>
 
       <div className="text-foreground absolute right-2 top-2 filter">
         <Select defaultValue={selectedColor} onValueChange={(value) => setSelectedColor(value)}>

--- a/packages/ui/primitives/signature-pad/signature-pad.tsx
+++ b/packages/ui/primitives/signature-pad/signature-pad.tsx
@@ -428,17 +428,6 @@ export const SignaturePad = ({
         </div>
       )}
 
-      <div className="text-foreground absolute left-2 top-2">
-        <input {...getInputProps()} />
-        <button
-          type="button"
-          className="focus-visible:ring-ring ring-offset-background text-muted-foreground/60 hover:text-muted-foreground rounded-full p-0 text-[0.688rem] focus-visible:outline-none focus-visible:ring-2"
-          onClick={open}
-        >
-          <Trans>Upload Image</Trans>
-        </button>
-      </div>
-
       <div className="text-foreground absolute right-2 top-2 filter">
         <Select defaultValue={selectedColor} onValueChange={(value) => setSelectedColor(value)}>
           <SelectTrigger className="h-auto w-auto border-none p-0.5">
@@ -478,6 +467,14 @@ export const SignaturePad = ({
       </div>
 
       <div className="absolute bottom-3 right-3 flex gap-2">
+        <input {...getInputProps()} />
+        <button
+          type="button"
+          className="focus-visible:ring-ring ring-offset-background text-muted-foreground/60 hover:text-muted-foreground rounded-full p-0 text-[0.688rem] focus-visible:outline-none focus-visible:ring-2"
+          onClick={open}
+        >
+          <Trans>Upload Image</Trans>
+        </button>
         <button
           type="button"
           className="focus-visible:ring-ring ring-offset-background text-muted-foreground/60 hover:text-muted-foreground rounded-full p-0 text-[0.688rem] focus-visible:outline-none focus-visible:ring-2"


### PR DESCRIPTION
This should be helpful for using seals, stamps and chops on documents. The implementation is pretty straightforward, uploaded images are rendered directly onto the canvas.

We added a button to trigger the upload and has support for dragging and dropping.

We also split the field size into default and min variables so we can allow it to default to a bigger size while still allowing the small minimum size.


https://github.com/user-attachments/assets/fdaf0bb5-6fa5-4c39-a14e-67aa6e876fc0

