### PR TITLE
update resource name in terraform state

### DIFF
--- a/.github/workflows/signezily_infra_cicd.yml
+++ b/.github/workflows/signezily_infra_cicd.yml
@@ -61,8 +61,8 @@ jobs:
     strategy:
       matrix:
         environment:
-          - { name: "dev", tf_workspace: "service-documenso-dev", tfvars: "dev.tfvars" }
-          - { name: "prod", tf_workspace: "service-documenso-prod", tfvars: "prod.tfvars" }
+          - { name: "dev", tf_workspace: "signezily-dev", tfvars: "dev.tfvars" }
+          - { name: "prod", tf_workspace: "signezily-prod", tfvars: "prod.tfvars" }
 
     steps:
       - name: Checkout code

--- a/terraform/signezily-infra/ecs.tf
+++ b/terraform/signezily-infra/ecs.tf
@@ -1,4 +1,4 @@
-resource "aws_ecs_task_definition" "documenso" {
+resource "aws_ecs_task_definition" "signezily" {
   family                   = "${var.application}-${var.environment}"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"

--- a/terraform/signezily-infra/main.tf
+++ b/terraform/signezily-infra/main.tf
@@ -28,7 +28,7 @@ module "documenso" {
   lb_subnet_ids           = data.aws_subnets.prod_public.ids
   certificate_arn         = var.certificate_arn
   ecs_execution_role_arn  = module.documenso_execution_role.role
-  ecs_task_definition_arn = aws_ecs_task_definition.documenso.arn
+  ecs_task_definition_arn = aws_ecs_task_definition.signezily.arn
   environment             = var.environment
   lb_internal             = false
   cpu                     = var.cpu


### PR DESCRIPTION


## Description

To rename the resource without destroy and create, i used 
`terraform state mv aws_ecs_task_definition.documenso aws_ecs_task_definition.signezily` to move state, and confirmed that the state in our terraform cloud got updated from 'documenso' to 'signezily' as below.
<img width="811" alt="Screenshot 2025-02-25 at 5 09 42 PM" src="https://github.com/user-attachments/assets/b5a2da85-5a72-472e-81a8-36f137a8eedd" />

This PR reflect the state of aws_ecs_task_definition, in theory we won't have any plan change here.


