### PR TITLE
clean up every naming into signezily infra except DB

### DIFF
--- a/terraform/signezily-infra/ecs.tf
+++ b/terraform/signezily-infra/ecs.tf
@@ -4,8 +4,8 @@ resource "aws_ecs_task_definition" "signezily" {
   network_mode             = "awsvpc"
   cpu                      = var.cpu
   memory                   = var.memory
-  execution_role_arn       = module.documenso_execution_role.role
-  task_role_arn            = module.documenso_execution_role.role
+  execution_role_arn       = module.signezily_execution_role.role
+  task_role_arn            = module.signezily_execution_role.role
   container_definitions = jsonencode([
     {
       name  = "app",

--- a/terraform/signezily-infra/locals.tf
+++ b/terraform/signezily-infra/locals.tf
@@ -69,7 +69,7 @@ locals {
   common_secrets = concat([
     for name in local.secret_names : {
       name      = name,
-      valueFrom = "${aws_secretsmanager_secret.documenso.id}:${name}::"
+      valueFrom = "${aws_secretsmanager_secret.signezily.id}:${name}::"
     }
     ],
     local.additional_secrets,

--- a/terraform/signezily-infra/main.tf
+++ b/terraform/signezily-infra/main.tf
@@ -27,7 +27,7 @@ module "documenso" {
   ecs_subnet_ids          = data.aws_subnets.prod_private.ids
   lb_subnet_ids           = data.aws_subnets.prod_public.ids
   certificate_arn         = var.certificate_arn
-  ecs_execution_role_arn  = module.documenso_execution_role.role
+  ecs_execution_role_arn  = module.signezily_execution_role.role
   ecs_task_definition_arn = aws_ecs_task_definition.signezily.arn
   environment             = var.environment
   lb_internal             = false

--- a/terraform/signezily-infra/main.tf
+++ b/terraform/signezily-infra/main.tf
@@ -9,7 +9,7 @@ module "documenso_database" {
   ]
 }
 
-module "documenso_execution_role" {
+module "signezily_execution_role" {
   source      = "../modules/iam"
   application = var.application
   environment = var.environment

--- a/terraform/signezily-infra/main.tf
+++ b/terraform/signezily-infra/main.tf
@@ -17,7 +17,7 @@ module "signezily_execution_role" {
   json_policy = file("${path.module}/iam_role/execution_policy.json")
 }
 
-module "documenso" {
+module "signezily" {
   source                  = "../modules/fargate"
   vpc_id                  = data.aws_vpc.prod.id
   service_name            = var.service_name

--- a/terraform/signezily-infra/secrets.tf
+++ b/terraform/signezily-infra/secrets.tf
@@ -1,12 +1,12 @@
 # Credentials Secret
-resource "aws_secretsmanager_secret" "documenso" {
+resource "aws_secretsmanager_secret" "signezily" {
   name                    = "${var.environment}/${var.application}"
   recovery_window_in_days = 0
 }
 
 # Secret Version
 resource "aws_secretsmanager_secret_version" "sversion" {
-  secret_id     = aws_secretsmanager_secret.documenso.id
+  secret_id     = aws_secretsmanager_secret.signezily.id
   secret_string = <<EOF
    {
     "": "",


### PR DESCRIPTION

**This PR** 
- rename every `documenso` naming into `signezily` except DB module.


I have run the following terraform state mv to update the name

`terraform state mv module.documenso module.signezily`
`terraform state mv module.documenso_execution_role module.signezily_execution_role`
`terraform state mv aws_secretsmanager_secret.documenso aws_secretsmanager_secret.signezily`

and terraform plan show _no change_.