### PR TITLE
Rename db module to signezily_database

### DIFF
--- a/terraform/signezily-infra/main.tf
+++ b/terraform/signezily-infra/main.tf
@@ -1,4 +1,4 @@
-module "documenso_database" {
+module "signezily_database" {
   source      = "../modules/rds"
   del_protect = var.del_protect
   environment = var.environment


### PR DESCRIPTION
Update: 

As i wrongly merged the precedent [PR](https://github.com/ezily-io/signezily/pull/18), there is some discrepancy between state and the terraform file. More detail can be found in [this slack thread](https://ezily-io.slack.com/archives/C08G1KAFLNN/p1741077027753759).

---

This PR renames
 - db module from `documenso_database` into `signezily_database`
 
I have run the following command to rename the state
`terraform state mv module.documenso_database module.signezily_database`