### PR TITLE
Potential fix for code scanning alert no. 1: Use of password hash with insufficient computational effort

### DIFF
--- a/packages/lib/server-only/auth/hash.ts
+++ b/packages/lib/server-only/auth/hash.ts
@@ -15,5 +15,5 @@ export const compareSync = (password: string, hash: string) => {
 };
 
 export const hashString = (input: string) => {
-  return crypto.createHash('sha512').update(input).digest('hex');
+  return bcryptHashSync(input, SALT_ROUNDS);
 };


### PR DESCRIPTION
Potential fix for [https://github.com/ezily-io/signezily/security/code-scanning/1](https://github.com/ezily-io/signezily/security/code-scanning/1)

To fix the issue, replace the use of the generic cryptographic hash (SHA-512) in the `hashString` function with a password hashing function designed to be computationally expensive, such as bcrypt. This requires updating the `hashString` implementation in `packages/lib/server-only/auth/hash.ts` to use `bcryptHashSync`, already imported as part of the codebase. Additionally, ensure that when comparing hashes, the comparison function uses the corresponding bcrypt verify method.

Specifically:

- In `packages/lib/server-only/auth/hash.ts`, update `hashString` so that it uses `bcryptHashSync(input, SALT_ROUNDS)` instead of `crypto.createHash('sha512').update(input).digest('hex')`.
- If any other code expects a SHA-512 hash instead of bcrypt (e.g., token length/format), deal with migration or inform about needed followup, but do not assume such refactoring here.

No changes are required in the other two files for the actual hash function usage fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
